### PR TITLE
Bunch Of Ai Changes

### DIFF
--- a/Source/Game/SwatAICommon/Classes/Actions/EnemySpeechManagerAction.uc
+++ b/Source/Game/SwatAICommon/Classes/Actions/EnemySpeechManagerAction.uc
@@ -16,9 +16,16 @@ function TriggerOfficerEncounteredSpeech()
 		TriggerSpeech('AnnouncedSpottedOfficerSurprised');
 	}
 	else if (! ISwatAI(m_Pawn).IsAggressive() && (ISwatEnemy(m_Pawn).GetEnemySkill() < EnemySkill_High))
-	{
-		TriggerSpeech('AnnouncedSpottedOfficerScared');
-	}
+    {
+        if (FRand() < 0.5)
+        {
+            TriggerSpeech('AnnouncedSpottedOfficerScared');
+        }
+        else
+        {
+            TriggerSpeech('AnnouncedSpottedOfficerSurprised');
+        }
+    }
 	else
 	{
 		TriggerSpeech('AnnouncedSpottedOfficer');
@@ -53,6 +60,12 @@ function TriggerInvestigateSpeech()
 function TriggerBarricadeSpeech()
 {
 	TriggerSpeech('AnnouncedBarricade', true);
+}
+
+// Such a creative name I know -sandman332
+function TriggerBarricadingSpeech()
+{
+	TriggerSpeech('ReportedBarricading', true);
 }
 
 function TriggerUncompliantSpeech()

--- a/Source/Game/SwatAICommon/Classes/Actions/FleeAction.uc
+++ b/Source/Game/SwatAICommon/Classes/Actions/FleeAction.uc
@@ -400,9 +400,13 @@ latent function Flee()
 
     // post the move to goal and wait for it to complete
     CurrentMoveToActorGoal.postGoal(self);
+
+	// trigger the speech
+	ISwatEnemy(m_Pawn).GetEnemySpeechManagerAction().TriggerCallForHelpSpeech();
+
     WaitForGoal(CurrentMoveToActorGoal);
 
-    // remove the most to goal
+    // remove the move to goal
     CurrentMoveToActorGoal.unPostGoal(self);
 	CurrentMoveToActorGoal.Release();
 	CurrentMoveToActorGoal = None;


### PR DESCRIPTION
- Enemies now have a 50% chance to either play the announced officer scared speech, or the announced officer surprised speech.  Currently, no idea why the surprised speech isn't triggering.  What jose did sadly did not fix it.

- Also added in the missing "ReportedBarricading" line to the speech manager

- Suspects won't fire while regrouping if they can not hit their target.  (This was done to the flee action but not the regroup action)

- Fixed a spelling mistake in the regroupaction. 

- Enemies will now properly play the call for help speech when regrouping.  I also added this to the flee function as well.